### PR TITLE
Implement graphene tight‑binding example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+FC=gfortran
+FFLAGS=-O2
+LIBS=-llapack -lblas
+SRC=$(wildcard src/*.f90)
+OBJ=$(SRC:.f90=.o)
+
+all: graphene_tb
+
+%.o: %.f90
+	$(FC) $(FFLAGS) -c $< -o $@
+
+graphene_tb: $(OBJ)
+	$(FC) $(FFLAGS) -o $@ $(OBJ) $(LIBS)
+
+clean:
+	rm -f *.o src/*.o graphene_tb band.dat dos.dat

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# graphene
+# Graphene Tight-Binding Example
+
+This repository contains a minimal Fortran implementation of the
+2x2 nearest-neighbour tight-binding model for monolayer graphene.
+It calculates the band structure along a high symmetry path and the
+density of states using Gaussian smearing.
+
+## Directory Structure
+
+```
+├── src/
+│   ├── constants.f90   # physical constants and TB parameters
+│   ├── lattice.f90     # lattice vectors and k-path
+│   ├── kgrid.f90       # k-grid for DOS
+│   ├── hamiltonian.f90 # construct 2x2 Hamiltonian
+│   ├── diagonalize.f90 # LAPACK diagonalization
+│   ├── dos.f90         # density of states
+│   └── main.f90        # driver program
+└── plot/
+    ├── band.py         # band structure plot
+    └── dos.py          # DOS plot
+```
+
+## Building
+
+A simple Makefile is provided. Compile using
+
+```
+make
+```
+
+This requires `gfortran` and LAPACK/BLAS libraries.
+
+## Running
+
+After building, run
+
+```
+./graphene_tb
+```
+
+This produces `band.dat` and `dos.dat` files.
+Plot the results using Python:
+
+```
+python plot/band.py
+python plot/dos.py
+```
+
+which will generate `band.png` and `dos.png`.

--- a/plot/band.py
+++ b/plot/band.py
@@ -1,0 +1,15 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+data = np.loadtxt('band.dat')
+ks = data[:,0]
+E1 = data[:,1]
+E2 = data[:,2]
+plt.figure()
+plt.plot(ks,E1,label='Band 1')
+plt.plot(ks,E2,label='Band 2')
+plt.xlabel('k-path index')
+plt.ylabel('Energy (eV)')
+plt.legend()
+plt.tight_layout()
+plt.savefig('band.png')

--- a/plot/dos.py
+++ b/plot/dos.py
@@ -1,0 +1,12 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+data = np.loadtxt('dos.dat')
+E = data[:,0]
+D = data[:,1]
+plt.figure()
+plt.plot(E,D)
+plt.xlabel('Energy (eV)')
+plt.ylabel('DOS (arb. units)')
+plt.tight_layout()
+plt.savefig('dos.png')

--- a/src/constants.f90
+++ b/src/constants.f90
@@ -1,0 +1,7 @@
+module constants
+  implicit none
+  ! physical constants and tight-binding parameters
+  double precision, parameter :: pi = 3.14159265358979323846d0
+  double precision, parameter :: t = -2.7d0 ! nearest-neighbor hopping in eV
+  double precision, parameter :: a = 1.42d0 ! carbon-carbon distance in Angstroms
+end module constants

--- a/src/diagonalize.f90
+++ b/src/diagonalize.f90
@@ -1,0 +1,16 @@
+module diagonalize
+  implicit none
+contains
+  subroutine diag2x2(h,eigvec,eigval)
+    complex(8), intent(in) :: h(2,2)
+    complex(8), intent(out) :: eigvec(2,2)
+    double precision, intent(out) :: eigval(2)
+    complex(8) :: a(2,2)
+    complex(8) :: work(2*2)
+    double precision :: rwork(3*2-2)
+    integer :: info
+    a = h
+    eigvec = a
+    call zheev('V','U',2,eigvec,2,eigval,work,size(work),rwork,info)
+  end subroutine diag2x2
+end module diagonalize

--- a/src/dos.f90
+++ b/src/dos.f90
@@ -1,0 +1,29 @@
+module dos
+  implicit none
+contains
+  subroutine calc_dos(energies,weights,sigma,ne,emin,emax,edos)
+    double precision, intent(in) :: energies(:)
+    double precision, intent(in) :: weights(:)
+    double precision, intent(in) :: sigma
+    integer, intent(in) :: ne
+    double precision, intent(in) :: emin,emax
+    double precision, intent(out) :: edos(ne)
+    integer :: i,j,n
+    double precision :: e,step
+    n = size(energies)
+    step = (emax-emin)/real(ne-1)
+    do i=1,ne
+       e = emin + (i-1)*step
+       edos(i)=0.d0
+       do j=1,n
+          edos(i) = edos(i) + weights(j)*gauss(e-energies(j),sigma)
+       end do
+    end do
+  end subroutine calc_dos
+
+  pure function gauss(x,sigma) result(val)
+    double precision, intent(in) :: x,sigma
+    double precision :: val
+    val = exp(- (x/sigma)**2 /2.d0)/(sigma*sqrt(2.d0*pi))
+  end function gauss
+end module dos

--- a/src/hamiltonian.f90
+++ b/src/hamiltonian.f90
@@ -1,0 +1,26 @@
+module hamiltonian
+  use constants
+  implicit none
+  double precision, dimension(2,3), parameter :: delta = reshape([ &
+       0.d0, -a, &
+       sqrt(3.d0)/2.d0*a, 0.5d0*a, &
+       -sqrt(3.d0)/2.d0*a, 0.5d0*a ], [2,3])
+contains
+  subroutine construct_h(k,ham)
+    double precision, dimension(2), intent(in) :: k
+    complex(8), dimension(2,2), intent(out) :: ham
+    double precision :: freal, fimag, phase
+    integer :: i
+    freal=0.d0
+    fimag=0.d0
+    do i=1,3
+       phase = k(1)*delta(1,i) + k(2)*delta(2,i)
+       freal = freal + cos(phase)
+       fimag = fimag + sin(phase)
+    end do
+    ham(1,1)=0.d0
+    ham(2,2)=0.d0
+    ham(1,2)=t*(freal + cmplx(0.d0,-fimag))
+    ham(2,1)=conjg(ham(1,2))
+  end subroutine construct_h
+end module hamiltonian

--- a/src/kgrid.f90
+++ b/src/kgrid.f90
@@ -1,0 +1,19 @@
+module kgrid
+  use constants
+  implicit none
+contains
+  subroutine generate_kgrid(nkx,nky,kpts,weight)
+    integer, intent(in) :: nkx,nky
+    double precision, dimension(2,nkx*nky), intent(out) :: kpts
+    double precision, dimension(nkx*nky), intent(out) :: weight
+    integer :: i,j,idx
+    idx=0
+    do j=0,nky-1
+       do i=0,nkx-1
+          idx=idx+1
+          kpts(:,idx) = [2*pi*i/(nkx*a*sqrt(3.d0)), 2*pi*j/(nky*3.d0*a)]
+          weight(idx) = 1.d0/(nkx*nky)
+       end do
+    end do
+  end subroutine generate_kgrid
+end module kgrid

--- a/src/lattice.f90
+++ b/src/lattice.f90
@@ -1,0 +1,63 @@
+module lattice
+  use constants
+  implicit none
+  double precision, parameter :: sqrt3 = 1.7320508075688772d0
+  double precision, parameter :: a0 = sqrt3*a  ! lattice constant
+  double precision, parameter :: b = 4.0d0*pi/(sqrt3*a0)
+  ! primitive lattice vectors
+  double precision, dimension(2,2), parameter :: avec = reshape([ &
+       sqrt3/2*a0,  1.5d0*a, &
+       -sqrt3/2*a0, 1.5d0*a ], [2,2])
+  ! reciprocal lattice vectors
+  double precision, dimension(2,2), parameter :: bvec = reshape([ &
+       2*pi/(sqrt3*a), 2*pi/(3*a), &
+       -2*pi/(sqrt3*a), 2*pi/(3*a) ], [2,2])
+
+contains
+
+  subroutine high_symmetry_path(nk,path)
+    ! Returns k-path along Gamma-K-M-Gamma
+    integer, intent(in) :: nk
+    double precision, dimension(2,nk), intent(out) :: path
+    double precision :: gamma(2), kpoint(2), mpoint(2)
+    integer :: i, seg
+    integer :: nseg
+    double precision, dimension(3) :: seglen
+    nseg = 3
+    seglen = (/1.d0,1.d0,1.d0/)
+    gamma = [0.d0, 0.d0]
+    kpoint = [2.d0*pi/(3.d0*a), 2.d0*pi/(3.d0*sqrt3*a)]
+    mpoint = [pi/(sqrt3*a), pi/(3.d0*a)]
+    seglen(1) = norm2(kpoint - gamma)
+    seglen(2) = norm2(mpoint - kpoint)
+    seglen(3) = norm2(gamma - mpoint)
+    seglen = seglen/sum(seglen)
+    integer :: p1, p2
+    double precision, dimension(2) :: k1,k2
+    double precision :: t
+    p1 = 1
+    k1 = gamma
+    k2 = kpoint
+    do seg=1,nseg
+       select case(seg)
+       case(1)
+          k1 = gamma
+          k2 = kpoint
+       case(2)
+          k1 = kpoint
+          k2 = mpoint
+       case(3)
+          k1 = mpoint
+          k2 = gamma
+       end select
+       p2 = p1 + int(seglen(seg)*nk) - 1
+       if(seg==nseg) p2 = nk
+       do i=p1,p2
+          t = real(i - p1)/real(max(1,p2 - p1))
+          path(:,i) = (1.d0 - t)*k1 + t*k2
+       end do
+       p1 = p2 + 1
+    end do
+  end subroutine high_symmetry_path
+
+end module lattice

--- a/src/main.f90
+++ b/src/main.f90
@@ -1,0 +1,59 @@
+program graphene_tb
+  use constants
+  use lattice
+  use kgrid
+  use hamiltonian
+  use diagonalize
+  use dos
+  implicit none
+  integer, parameter :: nkpath = 200
+  integer, parameter :: nkx = 40, nky=40
+  integer, parameter :: ne = 400
+  double precision, dimension(2,nkpath) :: kpath
+  double precision, dimension(nkpath,2) :: ebands
+  double precision, dimension(2,2) :: h
+  complex(8), dimension(2,2) :: hc
+  complex(8), dimension(2,2) :: vec
+  double precision, dimension(2) :: eval
+  double precision, dimension(2,nkx*nky) :: kpts
+  double precision, dimension(nkx*nky) :: kw
+  double precision, dimension(2*nkx*nky) :: egrid
+  double precision :: emin, emax
+  double precision, dimension(ne) :: dosdata
+  integer :: i,j,idx
+
+  call high_symmetry_path(nkpath,kpath)
+
+  do i=1,nkpath
+     call construct_h(kpath(:,i),hc)
+     call diag2x2(hc,vec,eval)
+     ebands(i,1)=eval(1)
+     ebands(i,2)=eval(2)
+  end do
+
+  open(unit=10,file='band.dat',status='replace')
+  do i=1,nkpath
+     write(10,'(3f12.6)') real(i), ebands(i,1), ebands(i,2)
+  end do
+  close(10)
+
+  call generate_kgrid(nkx,nky,kpts,kw)
+  idx=0
+  do i=1,nkx*nky
+     call construct_h(kpts(:,i),hc)
+     call diag2x2(hc,vec,eval)
+     egrid(idx*2+1)=eval(1)
+     egrid(idx*2+2)=eval(2)
+     idx=idx+1
+  end do
+
+  emin = minval(egrid) - 1.d0
+  emax = maxval(egrid) + 1.d0
+  call calc_dos(egrid,spread(kw,1,2),0.05d0,ne,emin,emax,dosdata)
+
+  open(unit=11,file='dos.dat',status='replace')
+  do i=1,ne
+     write(11,'(2f12.6)') emin + (i-1)*(emax-emin)/(ne-1), dosdata(i)
+  end do
+  close(11)
+end program graphene_tb


### PR DESCRIPTION
## Summary
- create Fortran source files for 2×2 tight-binding graphene model
- add simple Makefile to build with gfortran
- provide plotting scripts for band structure and DOS
- update README with build and run instructions

## Testing
- `make` *(fails: `gfortran` not found)*